### PR TITLE
fix: Don't pin any dependencies

### DIFF
--- a/cfg/renovate.json
+++ b/cfg/renovate.json
@@ -8,7 +8,6 @@
   "extends": [
     "config:base",
     ":followTag(typescript, latest)",
-    ":pinOnlyDevDependencies",
     "packages:eslint",
     "group:nodeJs",
     "group:codemirror",
@@ -41,8 +40,7 @@
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
     ":semanticCommitScope(deps)",
-    ":enableVulnerabilityAlerts",
-    ":pinAllExceptPeerDependencies"
+    ":enableVulnerabilityAlerts"
   ],
   "branchPrefix": "renovate-",
   "prConcurrentLimit": 5,


### PR DESCRIPTION
This is to prevent libraries' dependencies from breaking when used alongside other libraries that require a different version of that library.